### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ To run this project:
 3. Run `npm start`
 
 *Must provide own Clarafai API key in image.js file*
+
+To see it on REPL, click on:
+[![Run on Repl.it](https://repl.it/badge/github/BigT1305/smart-brain-api)](https://repl.it/github/BigT1305/smart-brain-api)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).